### PR TITLE
fixed title frame in latex beamer template

### DIFF
--- a/LaTeX-Beamer/beamerouterthemeTUKL.sty
+++ b/LaTeX-Beamer/beamerouterthemeTUKL.sty
@@ -80,7 +80,7 @@
 			\vfill%Hack
 			\iftukl@displayNavigation%
 				\ifnum\c@framenumber=1%
-					\relax%
+					\hspace*{1ex}\relax%
 				\else%
 	 				\insertnavigation{.5\paperwidth}%
 				\fi%


### PR DESCRIPTION
The boxes (Department on the left and TUK on the right) were misaligned on the first page using newer versions of LaTeX beamer. Inserting a small space between them restored the original layout.